### PR TITLE
feat: add arg to override sendmail path

### DIFF
--- a/gpgmail-postfix
+++ b/gpgmail-postfix
@@ -18,7 +18,7 @@
 
 usage() {
     cat << EOF
-usage: gpgmail-postfix (-d|-e|-s|-E) [-H|-S] [-g PATH] [-k KEYID] [-p PASSPHRASE] -r RECIPIENT [SENDMAIL_ARGS]
+usage: gpgmail-postfix (-d|-e|-s|-E) [-H|-S] [-g PATH] [-k KEYID] [-p PASSPHRASE] [--sendmailpath SENDMAIL_PATH] -r RECIPIENT [SENDMAIL_ARGS]
 
 OPTIONS:
     -d / --decrypt                  Decrypt E-mail
@@ -33,6 +33,8 @@ OPTIONS:
     -k / --key KEYID                PGP-key to use
     -p / --passphrase PASSPHRASE    Passphrase for PGP-key
     -r / --recipient RECIPIENT      E-mail recipient
+    
+    --sendmailpath SENDMAIL_PATH    Path to sendmail or other mail sending utility
 
     SENDMAIL_ARGS                   Arguments passed to sendmail
 
@@ -80,6 +82,8 @@ while true ; do
         -k|--key) GPGMAIL_key="--key=${2}" ; shift 2 ;;
         -p|--passphrase) GPGMAIL_passphrase="--passphrase=${2}"; shift 2 ;;
         -r|--recipient) RECIPIENT=$2; shift 2 ;;
+
+        --sendmailpath) SENDMAIL="${2}" ; shift 2 ;;
 
         -h|--help) usage ;;
         -v|--version) version ;;


### PR DESCRIPTION
This not only allows for non-standard sendmail paths (highly unlikely, but whatever), but also allows to specify a different mail sending utility (e.g. mail from mailutils). 

Being able to specify other mail sending utilities allows to not only inject the mails back to postfix via sendmail but also smtp. When mail is injected back via custom smtp port (e.g. 127.0.0.1:10026), you can configure a custom postfix configuration for that specific port. This is the same process that is used by https://github.com/infertux/zeyple.

This is useful for two reasons:
* allows to set content_filter=gpgmail for all mail ingress (instead of modifying `master.cf` for smtp, smtps, submission) and only excluse the reinjection-port
* allows to disable milter processing for reinjected mail (e.g. rspamd)