### PR TITLE
feat: add arg to override gpgmail path

### DIFF
--- a/gpgmail-postfix
+++ b/gpgmail-postfix
@@ -18,7 +18,7 @@
 
 usage() {
     cat << EOF
-usage: gpgmail-postfix (-d|-e|-s|-E) [-H|-S] [-g PATH] [-k KEYID] [-p PASSPHRASE] -r RECIPIENT [SENDMAIL_ARGS]
+usage: gpgmail-postfix (-d|-e|-s|-E) [-H|-S] [-g PATH] [-k KEYID] [-p PASSPHRASE] -r RECIPIENT [--gpgmailpath GPGMAIL_PATH] [SENDMAIL_ARGS]
 
 OPTIONS:
     -d / --decrypt                  Decrypt E-mail
@@ -33,6 +33,8 @@ OPTIONS:
     -k / --key KEYID                PGP-key to use
     -p / --passphrase PASSPHRASE    Passphrase for PGP-key
     -r / --recipient RECIPIENT      E-mail recipient
+    
+    --gpgmailpath GPGMAIL_PATH      Path to gpgmail
 
     SENDMAIL_ARGS                   Arguments passed to sendmail
 
@@ -81,6 +83,8 @@ while true ; do
         -p|--passphrase) GPGMAIL_passphrase="--passphrase=${2}"; shift 2 ;;
         -r|--recipient) RECIPIENT=$2; shift 2 ;;
 
+        --gpgmailpath) GPGMAIL="${2}" ; shift 2 ;;
+        
         -h|--help) usage ;;
         -v|--version) version ;;
         "") break ;;


### PR DESCRIPTION
to allow for non-standard gpgmail paths (such as /usr/local/bin/gpgmail)